### PR TITLE
Update DatabaseExtensionMethods.cs

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/DatabaseExtensionMethods.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/DatabaseExtensionMethods.cs
@@ -19,13 +19,17 @@ namespace EntityFramework.Utilities
 				// if you used master db as Initial Catalog, there is no need to change database
 				sqlconnection.ChangeDatabase("master");
 
-				var rollbackCommand = @"ALTER DATABASE [" + name + "] SET  SINGLE_USER WITH ROLLBACK IMMEDIATE;";
+				var nameParameter = new SqlParameter();
+				nameParameter.ParameterName = "@Name";
+				nameParameter.Value = name;
+
+				var rollbackCommand = @"ALTER DATABASE [@Name] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;";
 
 				var deletecommand = new SqlCommand(rollbackCommand, sqlconnection);
 
 				deletecommand.ExecuteNonQuery();
 
-				var deleteCommand = @"DROP DATABASE [" + name + "];";
+				var deleteCommand = @"DROP DATABASE [@Name];";
 
 				deletecommand = new SqlCommand(deleteCommand, sqlconnection);
 


### PR DESCRIPTION
As part of our regular security scans, a vulnerability was picked up in this library relating to SQL injection.

`DatabaseExtensionMethods.ForceDelete` takes a `name` parameter in the method signature and concatenates it directly in the SQL which is executed. I'm not sure exactly why this method exists outside of the unit tests, but the SQL should be parameterized.

The other option would be to just make this a private method which is only exposed to the tests, instead of a public extension method. Hopefully this would hide this vulnerability from the production code.