### PR TITLE
Add async support to batch operations

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EFBatchOperation.cs
@@ -9,6 +9,7 @@ using System.Data.SqlClient;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace EntityFramework.Utilities
 {
@@ -21,6 +22,15 @@ namespace EntityFramework.Utilities
 		/// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
 		/// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
 		void InsertAll<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T;
+
+		/// <summary>
+		/// Asynchronously bulk insert all items if the Provider supports it. Otherwise it will use the default asynchronous insert unless Configuration.DisableDefaultFallback is set to true in which case it would throw an exception.
+		/// </summary>
+		/// <param name="items">The items to insert</param>
+		/// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
+		/// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
+		Task InsertAllAsync<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T;
+
 		IEFBatchOperationFiltered<T> Where(Expression<Func<T, bool>> predicate);
 
 		/// <summary>
@@ -32,6 +42,16 @@ namespace EntityFramework.Utilities
 		/// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
 		/// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
 		void UpdateAll<TEntity>(IEnumerable<TEntity> items, Action<UpdateSpecification<TEntity>> updateSpecification, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T;
+
+		/// <summary>
+		/// Asynchronously bulk update all items if the Provider supports it. Otherwise it will use the default asynchronous update unless Configuration.DisableDefaultFallback is set to true in which case it would throw an exception.
+		/// </summary>
+		/// <typeparam name="TEntity"></typeparam>
+		/// <param name="items">The items to update</param>
+		/// <param name="updateSpecification">Define which columns to update</param>
+		/// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
+		/// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
+		Task UpdateAllAsync<TEntity>(IEnumerable<TEntity> items, Action<UpdateSpecification<TEntity>> updateSpecification, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T;
 	}
 
 	public class UpdateSpecification<T>
@@ -53,9 +73,13 @@ namespace EntityFramework.Utilities
 	public interface IEFBatchOperationFiltered<T>
 	{
 		int Delete(DbConnection connection = null);
+		Task<int> DeleteAsync(DbConnection connection = null);
 		int DeleteTop(int numberOfRows, DbConnection connection = null);
+		Task<int> DeleteTopAsync(int numberOfRows, DbConnection connection = null);
 		int DeleteTopPercent(double numberOfRows, DbConnection connection = null);
+		Task<int> DeleteTopPercentAsync(double numberOfRows, DbConnection connection = null);
 		int Update<TP>(Expression<Func<T, TP>> prop, Expression<Func<T, TP>> modifier, DbConnection connection = null);
+		Task<int> UpdateAsync<TP>(Expression<Func<T, TP>> prop, Expression<Func<T, TP>> modifier, DbConnection connection = null);
 	}
 
 	public static class EFBatchOperation
@@ -136,6 +160,54 @@ namespace EntityFramework.Utilities
 			Fallbacks.DefaultInsertAll(_context, items);
 		}
 
+		/// <summary>
+		/// Asynchronously bulk insert all items if the Provider supports it. Otherwise it will use the default asynchronous insert unless Configuration.DisableDefaultFallback is set to true in which case it would throw an exception.
+		/// </summary>
+		/// <param name="items">The items to insert</param>
+		/// <param name="connection">The DbConnection to use for the insert. Only needed when for example a profiler wraps the connection. Then you need to provide a connection of the type the provider use.</param>
+		/// <param name="batchSize">The size of each batch. Default depends on the provider. SqlProvider uses 15000 as default</param>
+		public async Task InsertAllAsync<TEntity>(IEnumerable<TEntity> items, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T
+		{
+			var con = _context.Connection as EntityConnection;
+			if (con == null && connection == null)
+			{
+				Configuration.Log("No provider could be found because the Connection didn't implement System.Data.EntityClient.EntityConnection");
+				await Fallbacks.DefaultInsertAllAsync(_context, items).ConfigureAwait(false);
+				return;
+			}
+
+			var connectionToUse = connection ?? con.StoreConnection;
+			var currentType = typeof(TEntity);
+			var provider = (IAsyncQueryProvider)Configuration.Providers.FirstOrDefault(p => p.CanHandle(connectionToUse) && p is IAsyncQueryProvider);
+
+			if (provider != null && provider.CanInsert)
+			{
+				var mapping = EfMappingFactory.GetMappingsForContext(_dbContext);
+				var typeMapping = mapping.TypeMappings[typeof(T)];
+				var tableMapping = typeMapping.TableMappings.First();
+
+				var properties = tableMapping.PropertyMappings
+					.Where(p => currentType.IsSubclassOf(p.ForEntityType) || p.ForEntityType == currentType)
+					.Where(p => p.IsComputed == false)
+					.Select(p => new ColumnMapping { NameInDatabase = p.ColumnName, NameOnObject = p.PropertyName }).ToList();
+
+				if (tableMapping.TphConfiguration != null)
+				{
+					properties.Add(new ColumnMapping
+					{
+						NameInDatabase = tableMapping.TphConfiguration.ColumnName,
+						StaticValue = tableMapping.TphConfiguration.Mappings[typeof(TEntity)]
+					});
+				}
+
+				await provider.InsertItemsAsync(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse, batchSize, executeTimeout, copyOptions, transaction).ConfigureAwait(false);
+				return;
+			}
+
+			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
+			await Fallbacks.DefaultInsertAllAsync(_context, items).ConfigureAwait(false);
+		}
+
 		public void UpdateAll<TEntity>(IEnumerable<TEntity> items, Action<UpdateSpecification<TEntity>> updateSpecification, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T
 		{
 			var con = _context.Connection as EntityConnection;
@@ -182,6 +254,52 @@ namespace EntityFramework.Utilities
 			throw new InvalidOperationException("No provider supporting the Update operation for this datasource was found");
 		}
 
+		public async Task UpdateAllAsync<TEntity>(IEnumerable<TEntity> items, Action<UpdateSpecification<TEntity>> updateSpecification, DbConnection connection = null, int? batchSize = null, int? executeTimeout = null, SqlBulkCopyOptions copyOptions = SqlBulkCopyOptions.Default, DbTransaction transaction = null) where TEntity : class, T
+		{
+			var con = _context.Connection as EntityConnection;
+			if (con == null && connection == null)
+			{
+				throw new InvalidOperationException("No provider supporting the Update operation for this datasource was found");
+			}
+
+			var connectionToUse = connection ?? con.StoreConnection;
+			var currentType = typeof(TEntity);
+			var provider = (IAsyncQueryProvider)Configuration.Providers.FirstOrDefault(p => p.CanHandle(connectionToUse) && p is IAsyncQueryProvider);
+
+			if (provider == null && con != null)
+			{
+				provider = (IAsyncQueryProvider)Configuration.Providers.FirstOrDefault(p => p.CanHandle(con.StoreConnection) && p is IAsyncQueryProvider);
+			}
+
+			if (provider != null && provider.CanBulkUpdate)
+			{
+				var mapping = EfMappingFactory.GetMappingsForContext(_dbContext);
+				var typeMapping = mapping.TypeMappings[typeof(T)];
+				var tableMapping = typeMapping.TableMappings.First();
+
+				var properties = tableMapping.PropertyMappings
+					.Where(p => currentType.IsSubclassOf(p.ForEntityType) || p.ForEntityType == currentType)
+					.Where(p => p.IsComputed == false)
+					.Select(p => new ColumnMapping
+					{
+						NameInDatabase = p.ColumnName,
+						NameOnObject = p.PropertyName,
+						DataType = p.DataType,
+						DataTypeFull = p.DataTypeFull,
+						IsPrimaryKey = p.IsPrimaryKey
+					}).ToList();
+
+				var spec = new UpdateSpecification<TEntity>();
+				updateSpecification(spec);
+				var insertConnection = !(connectionToUse is SqlConnection) && con?.StoreConnection is SqlConnection ? con.StoreConnection : connectionToUse;
+				await provider.UpdateItemsAsync(items, tableMapping.Schema, tableMapping.TableName, properties, connectionToUse, batchSize, spec, executeTimeout, copyOptions, transaction, insertConnection).ConfigureAwait(false);
+				return;
+			}
+
+			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
+			throw new InvalidOperationException("No provider supporting the Update operation for this datasource was found");
+		}
+
 		public IEFBatchOperationFiltered<T> Where(Expression<Func<T, bool>> predicate)
 		{
 			_predicate = predicate;
@@ -194,10 +312,22 @@ namespace EntityFramework.Utilities
 			return Delete(connection);
 		}
 
+		public Task<int> DeleteTopAsync(int numberOfRows, DbConnection connection = null)
+		{
+			_deleteTopExpression = $"TOP ({numberOfRows})";
+			return DeleteAsync(connection);
+		}
+
 		public int DeleteTopPercent(double percentOfRows, DbConnection connection = null)
 		{
 			_deleteTopExpression = $"TOP ({percentOfRows.ToString(CultureInfo.InvariantCulture)}) PERCENT";
 			return Delete(connection);
+		}
+
+		public Task<int> DeleteTopPercentAsync(double percentOfRows, DbConnection connection = null)
+		{
+			_deleteTopExpression = $"TOP ({percentOfRows.ToString(CultureInfo.InvariantCulture)}) PERCENT";
+			return DeleteAsync(connection);
 		}
 
 		public int Delete(DbConnection connection = null)
@@ -225,6 +355,33 @@ namespace EntityFramework.Utilities
 
 			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
 			return Fallbacks.DefaultDelete(_context, _predicate);
+		}
+
+		public async Task<int> DeleteAsync(DbConnection connection = null)
+		{
+			var con = _context.Connection as EntityConnection;
+			if (con == null && connection == null)
+			{
+				Configuration.Log("No provider could be found because the Connection didn't implement System.Data.EntityClient.EntityConnection");
+				return await Fallbacks.DefaultDeleteAsync(_context, _predicate).ConfigureAwait(false);
+			}
+			var connectionToUse = connection ?? con.StoreConnection;
+
+			var provider = (IAsyncQueryProvider)Configuration.Providers.FirstOrDefault(p => p.CanHandle(connectionToUse) && p is IAsyncQueryProvider);
+			if (provider != null && provider.CanDelete)
+			{
+				var set = _context.CreateObjectSet<T>();
+				var query = (ObjectQuery<T>)set.Where(_predicate);
+				var queryInformation = provider.GetQueryInformation(query);
+				queryInformation.TopExpression = _deleteTopExpression;
+
+				var delete = provider.GetDeleteQuery(queryInformation);
+				var parameters = query.Parameters.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name }).ToArray<object>();
+				return await _context.ExecuteStoreCommandAsync(delete, parameters).ConfigureAwait(false);
+			}
+
+			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
+			return await Fallbacks.DefaultDeleteAsync(_context, _predicate).ConfigureAwait(false);
 		}
 
 		public int Update<TP>(Expression<Func<T, TP>> prop, Expression<Func<T, TP>> modifier, DbConnection connection = null)
@@ -262,6 +419,43 @@ namespace EntityFramework.Utilities
 
 			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
 			return Fallbacks.DefaultUpdate(_context, _predicate, prop, modifier);
+		}
+
+		public async Task<int> UpdateAsync<TP>(Expression<Func<T, TP>> prop, Expression<Func<T, TP>> modifier, DbConnection connection = null)
+		{
+			var con = _context.Connection as EntityConnection;
+			if (con == null && connection == null)
+			{
+				Configuration.Log("No provider could be found because the Connection didn't implement System.Data.EntityClient.EntityConnection");
+				return await Fallbacks.DefaultUpdateAsync(_context, _predicate, prop, modifier).ConfigureAwait(false);
+			}
+			var connectionToUse = connection ?? con.StoreConnection;
+
+			var provider = (IAsyncQueryProvider)Configuration.Providers.FirstOrDefault(p => p.CanHandle(connectionToUse) && p is IAsyncQueryProvider);
+			if (provider != null && provider.CanUpdate)
+			{
+				var set = _context.CreateObjectSet<T>();
+
+				var query = (ObjectQuery<T>)set.Where(_predicate);
+				var queryInformation = provider.GetQueryInformation(query);
+
+				var updateExpression = ExpressionHelper.CombineExpressions(prop, modifier);
+
+				var mquery = (ObjectQuery<T>)_context.CreateObjectSet<T>().Where(updateExpression);
+				var mqueryInfo = provider.GetQueryInformation(mquery);
+
+				var update = provider.GetUpdateQuery(queryInformation, mqueryInfo);
+
+				var parameters = query.Parameters
+					.Concat(mquery.Parameters)
+					.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name })
+					.ToArray<object>();
+
+				return await _context.ExecuteStoreCommandAsync(update, parameters).ConfigureAwait(false);
+			}
+
+			Configuration.Log("Found provider: " + (provider?.GetType().Name ?? "[]") + " for " + connectionToUse.GetType().Name);
+			return await Fallbacks.DefaultUpdateAsync(_context, _predicate, prop, modifier).ConfigureAwait(false);
 		}
 	}
 }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/EntityFramework.Utilities.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
     <AssemblyName>RudeySH.EFUtilities</AssemblyName>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EntityFramework.Utilities/EntityFramework.Utilities/IAsyncQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/IAsyncQueryProvider.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+
+namespace EntityFramework.Utilities
+{
+	/// <summary>
+	///     An extension of <see cref="IQueryProvider"/> that offers asynchronous versions of database interactions.
+	/// </summary>
+	public interface IAsyncQueryProvider : IQueryProvider
+	{
+		Task InsertItemsAsync<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, int? executeTimeout, SqlBulkCopyOptions copyOptions, DbTransaction transaction);
+		Task UpdateItemsAsync<T>(IEnumerable<T> items, string schema, string tableName, IList<ColumnMapping> properties, DbConnection storeConnection, int? batchSize, UpdateSpecification<T> updateSpecification, int? executeTimeout, SqlBulkCopyOptions copyOptions, DbTransaction transaction, DbConnection insertConnection);
+	}
+}

--- a/EntityFramework.Utilities/Tests/FakeDomain/RenamedAndReorderedContext.cs
+++ b/EntityFramework.Utilities/Tests/FakeDomain/RenamedAndReorderedContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
+using System.Threading.Tasks;
 using Tests.Models;
 
 namespace Tests.FakeDomain
@@ -7,7 +8,7 @@ namespace Tests.FakeDomain
 	public class RenamedAndReorderedContext : DbContext
 	{
 		public RenamedAndReorderedContext()
-			: base(ConnectionStringReader.ConnectionStrings.SqlServer)
+			: base(ConnectionStringsFixture.ConnectionStrings.SqlServer)
 		{
 			Database.DefaultConnectionFactory = new SqlConnectionFactory("System.Data.SqlServer");
 			Database.SetInitializer(new CreateDatabaseIfNotExists<RenamedAndReorderedContext>());
@@ -39,6 +40,21 @@ namespace Tests.FakeDomain
 				db.Database.Create();
 				db.Database.ExecuteSqlCommand("drop table dbo.RenamedAndReorderedBlogPosts;");
 				db.Database.ExecuteSqlCommand(RenamedAndReorderedBlogPost.CreateTableSql());
+			}
+		}
+
+		public static async Task SetupTestDbAsync()
+		{
+			using (var db = new RenamedAndReorderedContext())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+				await db.Database.ExecuteSqlCommandAsync("drop table dbo.RenamedAndReorderedBlogPosts;");
+				await db.Database.ExecuteSqlCommandAsync(RenamedAndReorderedBlogPost.CreateTableSql());
 			}
 		}
 	}

--- a/EntityFramework.Utilities/Tests/InsertTests.cs
+++ b/EntityFramework.Utilities/Tests/InsertTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
+using System.Threading.Tasks;
 using EntityFramework.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Tests.FakeDomain;
@@ -42,6 +44,37 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task InsertAllAsync_InsertItems_WithTypeHierarchy()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var people = new List<Contact>
+				{
+					Contact.Build("FN1", "LN1", "Director"),
+					Contact.Build("FN2", "LN2", "Associate"),
+					Contact.Build("FN3", "LN3", "Vice President")
+				};
+
+				await EFBatchOperation.For(db, db.People).InsertAllAsync(people);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var contacts = db.People.OfType<Contact>().OrderBy(c => c.FirstName).ToList();
+				Assert.AreEqual(3, contacts.Count);
+				Assert.AreEqual("FN1", contacts.First().FirstName);
+				Assert.AreEqual("Director", contacts.First().Title);
+			}
+		}
+
+		[TestMethod]
 		public void InsertAll_InsertItems_WithTypeHierarchyBase()
 		{
 			using (var db = Context.Sql())
@@ -66,6 +99,36 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var contacts = db.People.OrderBy(c => c.FirstName).ToList();
+				Assert.AreEqual(3, contacts.Count);
+				Assert.AreEqual("FN1", contacts.First().FirstName);
+			}
+		}
+
+		[TestMethod]
+		public async Task InsertAllAsync_InsertItems_WithTypeHierarchyBase()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var people = new List<Person>
+				{
+					Person.Build("FN1", "LN1"),
+					Person.Build("FN2", "LN2"),
+					Person.Build("FN3", "LN3")
+				};
+
+				await EFBatchOperation.For(db, db.People).InsertAllAsync(people);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var contacts = await db.People.OrderBy(c => c.FirstName).ToListAsync();
 				Assert.AreEqual(3, contacts.Count);
 				Assert.AreEqual("FN1", contacts.First().FirstName);
 			}
@@ -101,6 +164,35 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task InsertAllAsync_InsertsItems()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var list = new List<BlogPost>
+				{
+					BlogPost.Create("T1"),
+					BlogPost.Create("T2"),
+					BlogPost.Create("T3")
+				};
+
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(3, await db.BlogPosts.CountAsync());
+				Assert.AreEqual("m@m.com", (await db.BlogPosts.FirstAsync()).Author.Email);
+			}
+		}
+
+		[TestMethod]
 		public void InsertAll_WithExplicitConnection_InsertsItems()
 		{
 			using (var db = Context.Sql())
@@ -124,6 +216,33 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				Assert.AreEqual(3, db.BlogPosts.Count());
+			}
+		}
+
+		[TestMethod]
+		public async Task InsertAllAsync_WithExplicitConnection_InsertsItems()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var list = new List<BlogPost>
+				{
+					BlogPost.Create("T1"),
+					BlogPost.Create("T2"),
+					BlogPost.Create("T3")
+				};
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list, db.Database.Connection);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(3, await db.BlogPosts.CountAsync());
 			}
 		}
 
@@ -159,6 +278,37 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task InsertAllAsync_WrongColumnOrder_InsertsItems()
+		{
+			using (var db = new ReorderedContext())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+			}
+
+			using (var db = Context.Sql())
+			{
+				var list = new List<BlogPost>
+				{
+					BlogPost.Create("T1"),
+					BlogPost.Create("T2"),
+					BlogPost.Create("T3")
+				};
+
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(3, await db.BlogPosts.CountAsync());
+			}
+		}
+
+		[TestMethod]
 		public void InsertAll_WrongColumnOrderAndRenamedColumn_InsertsItems()
 		{
 			using (var db = new RenamedAndReorderedContext())
@@ -188,6 +338,39 @@ namespace Tests
 			using (var db = new RenamedAndReorderedContext())
 			{
 				Assert.AreEqual(3, db.BlogPosts.Count());
+			}
+		}
+
+		[TestMethod]
+		public async Task InsertAllAsync_WrongColumnOrderAndRenamedColumn_InsertsItems()
+		{
+			using (var db = new RenamedAndReorderedContext())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+				await db.Database.ExecuteSqlCommandAsync("drop table dbo.RenamedAndReorderedBlogPosts;");
+				await db.Database.ExecuteSqlCommandAsync(RenamedAndReorderedBlogPost.CreateTableSql());
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var list = new List<RenamedAndReorderedBlogPost>
+				{
+					RenamedAndReorderedBlogPost.Create("T1"),
+					RenamedAndReorderedBlogPost.Create("T2"),
+					RenamedAndReorderedBlogPost.Create("T3")
+				};
+
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list);
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				Assert.AreEqual(3, await db.BlogPosts.CountAsync());
 			}
 		}
 
@@ -229,6 +412,43 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task InsertAllAsync_NoProvider_UsesDefaultInsert()
+		{
+			string fallbackText = null;
+			Configuration.DisableDefaultFallback = false;
+			Configuration.Log = str => fallbackText = str;
+
+			using (var db = Context.SqlCe())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+			}
+
+			var list = new List<BlogPost>
+			{
+				BlogPost.Create("T1"),
+				BlogPost.Create("T2"),
+				BlogPost.Create("T3")
+			};
+
+			using (var db = Context.SqlCe())
+			{
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list);
+			}
+
+			using (var db = Context.SqlCe())
+			{
+				Assert.AreEqual(3, await db.BlogPosts.CountAsync());
+			}
+
+			Assert.IsNotNull(fallbackText);
+		}
+
+		[TestMethod]
 		public void InsertAll_WithForeignKey()
 		{
 			int postId;
@@ -259,6 +479,40 @@ namespace Tests
 			{
 				Assert.AreEqual(2, db.Comments.Count());
 				Assert.AreEqual(2, db.Comments.Count(c => c.PostId == postId));
+			}
+		}
+
+		[TestMethod]
+		public async Task InsertAllAsync_WithForeignKey()
+		{
+			int postId;
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var bp = BlogPost.Create("B1");
+				db.BlogPosts.Add(bp);
+				await db.SaveChangesAsync();
+				postId = bp.Id;
+
+				var comments = new List<Comment>
+				{
+					new Comment{Text = "C1", PostId = bp.Id },
+					new Comment{Text = "C2", PostId = bp.Id }
+				};
+
+				await EFBatchOperation.For(db, db.Comments).InsertAllAsync(comments);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(2, await db.Comments.CountAsync());
+				Assert.AreEqual(2, await db.Comments.CountAsync(c => c.PostId == postId));
 			}
 		}
 	}

--- a/EntityFramework.Utilities/Tests/RenamedColumnsUpdateAllTest.cs
+++ b/EntityFramework.Utilities/Tests/RenamedColumnsUpdateAllTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.Entity;
 using System.Linq;
+using System.Threading.Tasks;
 using EntityFramework.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Tests.FakeDomain;
@@ -38,6 +39,32 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_SetDateTimeValueFromVariable_RenamedColumn()
+		{
+			await RenamedAndReorderedContext.SetupTestDbAsync();
+			using (var db = new RenamedAndReorderedContext())
+			{
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T1", Created = new DateTime(2013, 01, 01) });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T2", Created = new DateTime(2013, 02, 01) });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T3", Created = new DateTime(2013, 03, 01) });
+
+				await db.SaveChangesAsync();
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Created, b => DateTime.Today);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
+				Assert.AreEqual(DateTime.Today, post.Created);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_IncrementDateTime_RenamedColumn()
 		{
 			RenamedAndReorderedContext.SetupTestDb();
@@ -64,6 +91,32 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_IncrementDateTime_RenamedColumn()
+		{
+			await RenamedAndReorderedContext.SetupTestDbAsync();
+			using (var db = new RenamedAndReorderedContext())
+			{
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T1", Created = new DateTime(2013, 01, 01) });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T2", Created = new DateTime(2013, 02, 01) });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T3", Created = new DateTime(2013, 03, 01) });
+
+				await db.SaveChangesAsync();
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Created, b => DbFunctions.AddDays(b.Created, 1));
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
+				Assert.AreEqual(new DateTime(2013, 02, 02), post.Created);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_IncrementIntValue_RenamedColumn()
 		{
 			RenamedAndReorderedContext.SetupTestDb();
@@ -85,6 +138,32 @@ namespace Tests
 			using (var db = new RenamedAndReorderedContext())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T2");
+				Assert.AreEqual(110, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_IncrementIntValue_RenamedColumn()
+		{
+			await RenamedAndReorderedContext.SetupTestDbAsync();
+			using (var db = new RenamedAndReorderedContext())
+			{
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T1", Created = new DateTime(2013, 01, 01) });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T2", Created = new DateTime(2013, 02, 01), Reads = 10 });
+				db.BlogPosts.Add(new RenamedAndReorderedBlogPost { Title = "T3", Created = new DateTime(2013, 03, 01) });
+
+				await db.SaveChangesAsync();
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => b.Reads + 100);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = new RenamedAndReorderedContext())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
 				Assert.AreEqual(110, post.Reads);
 			}
 		}

--- a/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
+++ b/EntityFramework.Utilities/Tests/UpdateBulkTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
+using System.Threading.Tasks;
 using EntityFramework.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Tests.FakeDomain;
@@ -29,6 +31,30 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var posts = db.BlogPosts.OrderBy(b => b.Id).ToList();
+				Assert.AreEqual("T4", posts[0].Title);
+				Assert.AreEqual("T8", posts[1].Title);
+				Assert.AreEqual("T12", posts[2].Title);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateBulkAsync_UpdatesAll()
+		{
+			await SetupAsync();
+
+			using (var db = Context.Sql())
+			{
+				var posts = await db.BlogPosts.ToListAsync();
+				foreach (var post in posts)
+				{
+					post.Title = post.Title.Replace("1", "4").Replace("2", "8").Replace("3", "12");
+				}
+				await EFBatchOperation.For(db, db.BlogPosts).UpdateAllAsync(posts, spec => spec.ColumnsToUpdate(p => p.Title));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var posts = await db.BlogPosts.OrderBy(b => b.Id).ToListAsync();
 				Assert.AreEqual("T4", posts[0].Title);
 				Assert.AreEqual("T8", posts[1].Title);
 				Assert.AreEqual("T12", posts[2].Title);
@@ -74,6 +100,44 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateBulkAsync_CanUpdateComplexType()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.ForceDelete();
+				}
+				db.Database.Create();
+
+				var list = new List<ObjectWithComplexType>
+				{
+					new ObjectWithComplexType()
+				};
+
+				await EFBatchOperation.For(db, db.ObjectsWithComplexType).InsertAllAsync(list);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var items = await db.ObjectsWithComplexType.ToListAsync();
+				foreach (var item in items)
+				{
+					item.ComplexType.Name = "Test1";
+					item.ComplexType.Another.Name = "Test2";
+				}
+				await EFBatchOperation.For(db, db.ObjectsWithComplexType).UpdateAllAsync(items, spec => spec.ColumnsToUpdate(p => p.ComplexType.Name, p => p.ComplexType.Another.Name));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var item = await db.ObjectsWithComplexType.FirstAsync();
+				Assert.AreEqual("Test1", item.ComplexType.Name);
+				Assert.AreEqual("Test2", item.ComplexType.Another.Name);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateBulk_CanUpdateTPH()
 		{
 			using (var db = Context.Sql())
@@ -113,6 +177,45 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateBulkAsync_CanUpdateTPH()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+				db.Database.Create();
+
+				var people = new List<Contact>();
+				people.Add(Contact.Build("FN1", "LN1", "Director"));
+				people.Add(Contact.Build("FN2", "LN2", "Associate"));
+				people.Add(Contact.Build("FN3", "LN3", "Vice President"));
+
+				await EFBatchOperation.For(db, db.People).InsertAllAsync(people);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var contacts = db.Contacts.ToList();
+
+				foreach (var contact in contacts)
+				{
+					contact.FirstName = contact.Title + " " + contact.FirstName;
+				}
+
+				await EFBatchOperation.For(db, db.People).UpdateAllAsync(contacts, x => x.ColumnsToUpdate(p => p.FirstName));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var contacts = await db.People.OfType<Contact>().OrderBy(c => c.LastName).ToListAsync();
+				Assert.AreEqual(3, contacts.Count);
+				Assert.AreEqual("Director FN1", contacts.First().FirstName);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateBulk_CanUpdateNumerics()
 		{
 			using (var db = Context.Sql())
@@ -146,6 +249,46 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var item = db.NumericTestsObjects.First();
+				Assert.AreEqual(1.1m, item.DecimalType);
+				Assert.AreEqual(2.1f, item.FloatType);
+				Assert.AreEqual(3.1m, item.NumericType);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateBulkAsync_CanUpdateNumerics()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.ForceDelete();
+				}
+				db.Database.Create();
+
+				var list = new List<NumericTestObject>
+				{
+					new NumericTestObject()
+				};
+
+				await EFBatchOperation.For(db, db.NumericTestsObjects).InsertAllAsync(list);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var items = await db.NumericTestsObjects.ToListAsync();
+				foreach (var item in items)
+				{
+					item.DecimalType = 1.1m;
+					item.FloatType = 2.1f;
+					item.NumericType = 3.1m;
+				}
+				await EFBatchOperation.For(db, db.NumericTestsObjects).UpdateAllAsync(items, spec => spec.ColumnsToUpdate(p => p.DecimalType, p => p.FloatType, p => p.NumericType));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var item = await db.NumericTestsObjects.FirstAsync();
 				Assert.AreEqual(1.1m, item.DecimalType);
 				Assert.AreEqual(2.1f, item.FloatType);
 				Assert.AreEqual(3.1m, item.NumericType);
@@ -193,6 +336,46 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateBulkAsync_CanUpdateMultiPK()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.ForceDelete();
+				}
+				db.Database.Create();
+
+				var guid = Guid.NewGuid();
+				var list = new List<MultiPkObject>
+				{
+					new MultiPkObject{ Pk1 = guid, Pk2 = 0 },
+					new MultiPkObject{ Pk1 = guid, Pk2 = 1 }
+				};
+
+				await EFBatchOperation.For(db, db.MultiPkObjects).InsertAllAsync(list);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var items = await db.MultiPkObjects.ToListAsync();
+				var index = 1;
+				foreach (var item in items)
+				{
+					item.Text = "#" + index++;
+				}
+				await EFBatchOperation.For(db, db.MultiPkObjects).UpdateAllAsync(items, spec => spec.ColumnsToUpdate(p => p.Text));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var items = await db.MultiPkObjects.OrderBy(x => x.Pk2).ToListAsync();
+				Assert.AreEqual("#1", items[0].Text);
+				Assert.AreEqual("#2", items[1].Text);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateBulk_CanUpdateNvarcharWithLength()
 		{
 			Setup();
@@ -210,6 +393,30 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var posts = db.BlogPosts.OrderBy(b => b.Id).ToList();
+				Assert.AreEqual("T4", posts[0].ShortTitle);
+				Assert.AreEqual("T8", posts[1].ShortTitle);
+				Assert.AreEqual("T12", posts[2].ShortTitle);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateBulkAsync_CanUpdateNvarcharWithLength()
+		{
+			await SetupAsync();
+
+			using (var db = Context.Sql())
+			{
+				var posts = await db.BlogPosts.ToListAsync();
+				foreach (var post in posts)
+				{
+					post.ShortTitle = post.Title.Replace("1", "4").Replace("2", "8").Replace("3", "12");
+				}
+				await EFBatchOperation.For(db, db.BlogPosts).UpdateAllAsync(posts, spec => spec.ColumnsToUpdate(p => p.ShortTitle));
+			}
+
+			using (var db = Context.Sql())
+			{
+				var posts = await db.BlogPosts.OrderBy(b => b.Id).ToListAsync();
 				Assert.AreEqual("T4", posts[0].ShortTitle);
 				Assert.AreEqual("T8", posts[1].ShortTitle);
 				Assert.AreEqual("T12", posts[2].ShortTitle);
@@ -234,6 +441,27 @@ namespace Tests
 				};
 
 				EFBatchOperation.For(db, db.BlogPosts).InsertAll(list);
+			}
+		}
+
+		private static async Task SetupAsync()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.ForceDelete();
+				}
+				db.Database.Create();
+
+				var list = new List<BlogPost>
+				{
+					BlogPost.Create("T1"),
+					BlogPost.Create("T2"),
+					BlogPost.Create("T3")
+				};
+
+				await EFBatchOperation.For(db, db.BlogPosts).InsertAllAsync(list);
 			}
 		}
 	}

--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Data.Entity;
 using System.Linq;
+using System.Threading.Tasks;
 using EntityFramework.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Tests.FakeDomain;
@@ -29,6 +31,24 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_Increment()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => b.Reads + 5);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
+				Assert.AreEqual(5, post.Reads);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_Set()
 		{
 			SetupBasePosts();
@@ -42,6 +62,24 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T2");
+				Assert.AreEqual(10, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_Set()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => 10);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
 				Assert.AreEqual(10, post.Reads);
 			}
 		}
@@ -61,6 +99,25 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T2");
+				Assert.AreEqual(20, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_SetFromVariable()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var reads = 20;
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => reads);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
 				Assert.AreEqual(20, post.Reads);
 			}
 		}
@@ -91,6 +148,25 @@ namespace Tests
 
 		[TestMethod]
 		[Ignore]
+		public async Task UpdateAllAsync_SetFromMethod()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => Get20());
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
+				Assert.AreEqual(20, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		[Ignore]
 		public void UpdateAll_SetFromProperty()
 		{
 			SetupBasePosts();
@@ -98,6 +174,19 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Created == DateTime.Now.AddDays(2)).Update(b => b.Created, b => DateTime.Now);
+				Assert.AreEqual(1, count);
+			}
+		}
+
+		[TestMethod]
+		[Ignore]
+		public async Task UpdateAllAsync_SetFromProperty()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Created == DateTime.Now.AddDays(2)).UpdateAsync(b => b.Created, b => DateTime.Now);
 				Assert.AreEqual(1, count);
 			}
 		}
@@ -122,6 +211,25 @@ namespace Tests
 		}
 
 		[TestMethod]
+		[Ignore]
+		public async Task UpdateAllAsync_ConcatStringValue()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Title, b => b.Title + ".0");
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(1, await db.BlogPosts.CountAsync(p => p.Title == "T2.0"));
+				Assert.AreEqual(0, await db.BlogPosts.CountAsync(p => p.Title == "T2"));
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_SetDateTimeValueFromVariable()
 		{
 			SetupBasePosts();
@@ -135,6 +243,24 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T2");
+				Assert.AreEqual(DateTime.Today, post.Created);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_SetDateTimeValueFromVariable()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Created, b => DateTime.Today);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
 				Assert.AreEqual(DateTime.Today, post.Created);
 			}
 		}
@@ -158,6 +284,24 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_Decrement()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => b.Reads - 5);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
+				Assert.AreEqual(-5, post.Reads);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_Multiply()
 		{
 			SetupBasePosts();
@@ -176,6 +320,24 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_Multiply()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T1").UpdateAsync(b => b.Reads, b => b.Reads * 2);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T1");
+				Assert.AreEqual(4, post.Reads);
+			}
+		}
+
+		[TestMethod]
 		public void UpdateAll_Divide()
 		{
 			SetupBasePosts();
@@ -189,6 +351,24 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T1");
+				Assert.AreEqual(1, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_Divide()
+		{
+			await SetupBasePostsAsync();
+
+			using (var db = Context.Sql())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T1").UpdateAsync(b => b.Reads, b => b.Reads / 2);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T1");
 				Assert.AreEqual(1, post.Reads);
 			}
 		}
@@ -232,6 +412,44 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public async Task UpdateAllAsync_NoProvider_UsesDefaultDelete()
+		{
+			string fallbackText = null;
+			Configuration.DisableDefaultFallback = false;
+			Configuration.Log = str => fallbackText = str;
+
+			using (var db = Context.SqlCe())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				db.BlogPosts.Add(BlogPost.Create("T1", DateTime.Today.AddDays(-2)));
+				db.BlogPosts.Add(BlogPost.Create("T2", DateTime.Today.AddDays(0)));
+				db.BlogPosts.Add(BlogPost.Create("T3", DateTime.Today.AddDays(2)));
+
+				await db.SaveChangesAsync();
+			}
+
+			using (var db = Context.SqlCe())
+			{
+				var count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Title, b => b.Title + ".0");
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.SqlCe())
+			{
+				Assert.AreEqual(1, await db.BlogPosts.CountAsync(p => p.Title == "T2.0"));
+				Assert.AreEqual(0, await db.BlogPosts.CountAsync(p => p.Title == "T2"));
+			}
+
+			Assert.IsNotNull(fallbackText);
+		}
+
+		[TestMethod]
 		public void UpdateAll_Increment_WithExplicitConnection()
 		{
 			SetupBasePosts();
@@ -246,6 +464,25 @@ namespace Tests
 			using (var db = Context.Sql())
 			{
 				var post = db.BlogPosts.First(p => p.Title == "T2");
+				Assert.AreEqual(5, post.Reads);
+			}
+		}
+
+		[TestMethod]
+		public async Task UpdateAllAsync_Increment_WithExplicitConnection()
+		{
+			await SetupBasePostsAsync();
+
+			int count;
+			using (var db = Context.Sql())
+			{
+				count = await EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").UpdateAsync(b => b.Reads, b => b.Reads + 5, db.Database.Connection);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				var post = await db.BlogPosts.FirstAsync(p => p.Title == "T2");
 				Assert.AreEqual(5, post.Reads);
 			}
 		}
@@ -267,6 +504,26 @@ namespace Tests
 				db.BlogPosts.Add(BlogPost.Create("T2"));
 
 				db.SaveChanges();
+			}
+		}
+
+		private static async Task SetupBasePostsAsync()
+		{
+			using (var db = Context.Sql())
+			{
+				if (db.Database.Exists())
+				{
+					db.Database.Delete();
+				}
+
+				db.Database.Create();
+
+				var p = BlogPost.Create("T1");
+				p.Reads = 2;
+				db.BlogPosts.Add(p);
+				db.BlogPosts.Add(BlogPost.Create("T2"));
+
+				await db.SaveChangesAsync();
 			}
 		}
 	}


### PR DESCRIPTION
This adds async versions of all batch operations and their dependencies, and also adds async versions of all corresponding tests and their setup/teardown logic.

To avoid breaking changes, `IQueryProvider` is left untouched, and instead an `IAsyncQueryProvider` extension of it is added, and async batch operations look for an implementation of it in the provider collection, falling back to new async defaults if one isn't found. There is probably room for that fallback logic to be improved to be more configurable.

As a side effect, this bumps the C# version to 8. While C# 8 isn't fully supported by this project's target frameworks, C# 8 syntactic sugar is supported just fine. This was motivated by wanting `await using` to avoid very ugly code when multiple usings are used back-to-back.

Additionally, while .NET Framework supports `IAsyncDisposable`, it appears many classes only support it in .NET Standard, so a number of usings are wrapped in `#if`/`#else` blocks so that `await using` is only used if supported. See:

- [`DbCommand.DisposeAsync` Versions](https://learn.microsoft.com/en-us/dotnet/api/system.data.common.dbcommand.disposeasync#applies-to)
- [`DbDataReader.DisposeAsync` Versions](https://learn.microsoft.com/en-us/dotnet/api/system.data.common.dbdatareader.disposeasync#applies-to)
- [`IAsyncDisposable.DisposeAsync` Versions](https://learn.microsoft.com/en-us/dotnet/api/system.iasyncdisposable.disposeasync#applies-to)