### PR TITLE
Protect against queries EF optimizes down to dummy no-op queries when bulk updating and deleting

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/INoOpAnalyzer.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/INoOpAnalyzer.cs
@@ -1,0 +1,16 @@
+﻿namespace EntityFramework.Utilities
+{
+	/// <summary>
+	///     Provides analysis related to whether queries would perform no operation.
+	/// </summary>
+	public interface INoOpAnalyzer
+	{
+		/// <summary>
+		///     Determines whether the given query would perform no operation. Used to guard against queries Entity
+		///     Framework has optimized down to a dummy query against nothing that returns nothing.
+		/// </summary>
+		/// <param name="queryInformation">Information about the query.</param>
+		/// <returns>Whether the query would perform no operation.</returns>
+		bool QueryIsNoOp(QueryInformation queryInformation);
+	}
+}

--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 
 namespace EntityFramework.Utilities
 {
-	public class SqlQueryProvider : IQueryProvider
+	public class SqlQueryProvider : IQueryProvider, INoOpAnalyzer
 	{
 		public bool CanDelete => true;
 		public bool CanUpdate => true;
@@ -16,6 +16,12 @@ namespace EntityFramework.Utilities
 
 		private static readonly Regex FromRegex = new Regex(@"FROM \[([^\]]+)\]\.\[([^\]]+)\] AS (\[[^\]]+\])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 		private static readonly Regex UpdateRegex = new Regex(@"(\[[^\]]+\])[^=]+=(.+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+		/// <inheritdoc/>
+		public bool QueryIsNoOp(QueryInformation queryInformation) =>
+			string.IsNullOrEmpty(queryInformation.Schema) &&
+			string.IsNullOrEmpty(queryInformation.Table) &&
+			queryInformation.WhereSql.Contains("WHERE 1 = 0");
 
 		public string GetDeleteQuery(QueryInformation queryInfo)
 		{


### PR DESCRIPTION
While this is not compatible with the refactors coming up (especially since this would need to be duplicated to the async versions of methods), this demonstrates what fixed #33 for me; I use this in production.

Bulk delete and update are changed to abort if a query appears to be a dummy query against nothing that returns nothing.