### PR TITLE
Handle setting column value to null in update query

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -15,7 +15,7 @@ namespace EntityFramework.Utilities
 		public bool CanBulkUpdate => true;
 
 		private static readonly Regex FromRegex = new Regex(@"FROM \[([^\]]+)\]\.\[([^\]]+)\] AS (\[[^\]]+\])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-		private static readonly Regex UpdateRegex = new Regex(@"(\[[^\]]+\])[^=]+=(.+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex UpdateRegex = new Regex(@"(\[[^\]]+\])[^=]+(=|IS)(.+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 		/// <inheritdoc/>
 		public bool QueryIsNoOp(QueryInformation queryInformation) =>
@@ -40,7 +40,7 @@ namespace EntityFramework.Utilities
 			if (match.Success)
 			{
 				var col = match.Groups[1];
-				var rest = match.Groups[2].Value;
+				var rest = match.Groups[3].Value;
 
 				rest = SqlStringHelper.FixParantheses(rest);
 

--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -15,7 +15,7 @@ namespace EntityFramework.Utilities
 		public bool CanBulkUpdate => true;
 
 		private static readonly Regex FromRegex = new Regex(@"FROM \[([^\]]+)\]\.\[([^\]]+)\] AS (\[[^\]]+\])", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-		private static readonly Regex UpdateRegex = new Regex(@"(\[[^\]]+\])[^=]+(=|IS)(.+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+		private static readonly Regex UpdateRegex = new Regex(@"(\[[^\]]+\])[^=]+(?:=|IS)(.+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 		/// <inheritdoc/>
 		public bool QueryIsNoOp(QueryInformation queryInformation) =>
@@ -40,7 +40,7 @@ namespace EntityFramework.Utilities
 			if (match.Success)
 			{
 				var col = match.Groups[1];
-				var rest = match.Groups[3].Value;
+				var rest = match.Groups[2].Value;
 
 				rest = SqlStringHelper.FixParantheses(rest);
 

--- a/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
+++ b/EntityFramework.Utilities/Tests/UpdateByQueryTest.cs
@@ -103,6 +103,24 @@ namespace Tests
 		}
 
 		[TestMethod]
+		public void UpdateAll_SetNull()
+		{
+			SetupBasePosts();
+
+			using (var db = Context.Sql())
+			{
+				var count = EFBatchOperation.For(db, db.BlogPosts).Where(b => b.Title == "T2").Update(b => b.Title, b => null);
+				Assert.AreEqual(1, count);
+			}
+
+			using (var db = Context.Sql())
+			{
+				Assert.AreEqual(1, db.BlogPosts.Count(p => p.Title == null));
+				Assert.AreEqual(0, db.BlogPosts.Count(p => p.Title == "T2"));
+			}
+		}
+
+		[TestMethod]
 		[Ignore]
 		public void UpdateAll_ConcatStringValue()
 		{


### PR DESCRIPTION
The where statement for setting a property to null is an IS NULL operator which isn't handled in the update query. The resulting update query becomes a SET [COLUMN] IS NULL which is incorrect syntax.