### PR TITLE
Refactor parameter creation to use provider method

### DIFF
--- a/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/IQueryProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Entity;
+﻿using System.Data.Common;
+using System.Data.Entity;
 using System.Data.Entity.Core.Objects;
 
 namespace EntityFramework.Utilities;
@@ -37,4 +38,6 @@ public interface IQueryProvider
 	bool CanHandle(DbContext dbContext);
 
 	QueryInformation GetQueryInformation<T>(ObjectQuery<T> query);
+
+	DbParameter GetParameter(ObjectParameter parameter);
 }

--- a/EntityFramework.Utilities/EntityFramework.Utilities/Internal/EFBatchOperationImplementation.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/Internal/EFBatchOperationImplementation.cs
@@ -1,7 +1,6 @@
 ﻿using System.Data.Entity;
 using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
-using System.Data.SqlClient;
 using System.Globalization;
 using System.Linq.Expressions;
 
@@ -254,7 +253,7 @@ internal sealed class EFBatchOperationImplementation<TContext, TBaseEntity>
 			return 0;
 
 		var delete = provider.GetDeleteQuery(queryInformation);
-		var parameters = query.Parameters.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name }).ToArray<object>();
+		var parameters = query.Parameters.Select(provider.GetParameter).ToArray<object>();
 
 		if (transactionalBehavior != null)
 			return objectContext.ExecuteStoreCommand(transactionalBehavior.Value, delete, parameters);
@@ -281,7 +280,7 @@ internal sealed class EFBatchOperationImplementation<TContext, TBaseEntity>
 		queryInformation.TopExpression = topExpression;
 
 		var delete = provider.GetDeleteQuery(queryInformation);
-		var parameters = query.Parameters.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name }).ToArray<object>();
+		var parameters = query.Parameters.Select(provider.GetParameter).ToArray<object>();
 
 		if (transactionalBehavior != null)
 			return objectContext.ExecuteStoreCommandAsync(transactionalBehavior.Value, delete, cancellationToken, parameters);
@@ -326,7 +325,7 @@ internal sealed class EFBatchOperationImplementation<TContext, TBaseEntity>
 
 		var parameters = query.Parameters
 			.Concat(mquery.Parameters)
-			.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name })
+			.Select(provider.GetParameter)
 			.ToArray<object>();
 
 		if (transactionalBehavior != null)
@@ -364,7 +363,7 @@ internal sealed class EFBatchOperationImplementation<TContext, TBaseEntity>
 
 		var parameters = query.Parameters
 			.Concat(mquery.Parameters)
-			.Select(p => new SqlParameter { Value = p.Value, ParameterName = p.Name })
+			.Select(provider.GetParameter)
 			.ToArray<object>();
 
 		if (transactionalBehavior != null)

--- a/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
+++ b/EntityFramework.Utilities/EntityFramework.Utilities/SqlQueryProvider.cs
@@ -394,6 +394,11 @@ public class SqlQueryProvider : IQueryProvider, INoOpAnalyzer
 		return queryInfo;
 	}
 
+	public virtual DbParameter GetParameter(ObjectParameter parameter)
+	{
+		return new SqlParameter { Value = parameter.Value, ParameterName = parameter.Name };
+	}
+
 	private sealed class UpdateAllCommands
 	{
 		public string CreateTempTable { get; set; } = null!;


### PR DESCRIPTION
Introduced GetParameter method in IQueryProvider and implemented it in SqlQueryProvider to encapsulate DbParameter creation. EFBatchOperationImplementation no longer depends on System.Data.SqlClient.

fixes #36 